### PR TITLE
Stop dbg from silently swallowing downstream type errors

### DIFF
--- a/mshell/TypeCheckProgram.go
+++ b/mshell/TypeCheckProgram.go
@@ -53,10 +53,14 @@ func TypeCheckProgram(file *MShellFile, stdlibDefs []MShellDefinition) (errors [
 	out := make([]string, 0, len(checker.errors))
 	ok = true
 	for _, e := range checker.errors {
-		out = append(out, e.Format(arena, names))
-		if e.Severity == SeverityError {
-			ok = false
+		// Info-severity diagnostics (e.g. `dbg` dumps) are written to
+		// stderr directly by their source for the CLI path; skip them
+		// here so Main.go doesn't print them a second time.
+		if e.Severity != SeverityError {
+			continue
 		}
+		out = append(out, e.Format(arena, names))
+		ok = false
 	}
 	if len(out) == 0 {
 		return nil, true

--- a/mshell/TypeCheckProgram_test.go
+++ b/mshell/TypeCheckProgram_test.go
@@ -720,3 +720,29 @@ iff
 		t.Fatalf("expected unknown-identifier @local error; errs=%v", errs)
 	}
 }
+
+// Regression: a `dbg` token inside the branching driver appends a
+// SeverityInfo TypeError to flag the diagnostic for the LSP. Previously
+// tryBranchStep treated *any* error produced by a step as fatal and
+// killed the branch, which short-circuited driveBranches and skipped
+// every token after the `dbg`. The result: a real type error sitting
+// downstream of a `dbg` silently disappeared. Putting `dbg` in front of
+// a broken token "fixed" the error report, which is exactly the
+// symptom that surfaced this bug.
+func TestTypeCheckProgramDbgDoesNotSuppressLaterErrors(t *testing.T) {
+	// Without the fix, `dbg` swallows the error from `"x" +`.
+	errs, ok := parseAndCheck(t, `42 dbg "x" +`)
+	if ok {
+		t.Fatalf("expected type error after dbg to surface; errs=%v", errs)
+	}
+}
+
+func TestTypeCheckProgramDbgInValidProgramPasses(t *testing.T) {
+	// A valid program with `dbg` mid-stream still type-checks. The
+	// dbg dump is recorded as a SeverityInfo diagnostic but does not
+	// fail the program.
+	errs, ok := parseAndCheck(t, `42 dbg 1 + wl`)
+	if !ok {
+		t.Fatalf("expected valid program with dbg to pass; errs=%v", errs)
+	}
+}

--- a/mshell/TypeQuote.go
+++ b/mshell/TypeQuote.go
@@ -319,14 +319,30 @@ func (c *Checker) tryBranchStep(b quoteBranch, step func()) ([]quoteBranch, []Ty
 	spawned := c.branchSpawn
 	c.branchSpawn = savedSpawn
 	c.branchingEnabled = savedEnabled
+	// Info-severity diagnostics (e.g. `dbg` dumps) are passthroughs:
+	// they must not kill the branch, since the step still succeeded
+	// type-wise. Split them out and reattach to the parent's errors
+	// so they still surface in the final output.
+	var fatal []TypeError
+	var info []TypeError
+	for _, e := range produced {
+		if e.Severity == SeverityInfo {
+			info = append(info, e)
+		} else {
+			fatal = append(fatal, e)
+		}
+	}
+	if len(info) > 0 {
+		c.errors = append(c.errors, info...)
+	}
 	if len(spawned) > 0 {
-		if len(produced) > 0 {
-			c.errors = append(c.errors, produced...)
+		if len(fatal) > 0 {
+			c.errors = append(c.errors, fatal...)
 		}
 		return spawned, nil, true
 	}
-	if len(produced) > 0 {
-		return nil, produced, false
+	if len(fatal) > 0 {
+		return nil, fatal, false
 	}
 	return []quoteBranch{c.captureBranch()}, nil, true
 }


### PR DESCRIPTION
tryBranchStep treated any error produced by a step as fatal, killing the branch. emitDebugDump appends a SeverityInfo diagnostic, so landing on a dbg token short-circuited driveBranches and skipped every token after it — placing dbg in front of a broken token made its error vanish. Split produced errors by severity: info passes through to the parent's c.errors, only fatal errors kill the branch.

Also filter SeverityInfo out of TypeCheckProgram's CLI string output, since emitDebugDump already writes dbg dumps directly to stderr — otherwise Main.go printed them a second time when the program also had a hard error.