### PR TITLE
Add type checker signature for urlEncode

### DIFF
--- a/mshell/TypeBuiltins.go
+++ b/mshell/TypeBuiltins.go
@@ -1428,6 +1428,22 @@ func builtinSigsByName(arena *TypeArena, names *NameTable) map[NameId][]QuoteSig
 		Inputs:  []TypeId{TidStr},
 		Outputs: []TypeId{TidBytes},
 	}}
+	// urlEncode : (str -- str) | ({str: T} -- str)
+	//
+	// Dict input stays loose ({str: T}) because the runtime calls
+	// CastString on each value (and on each item if the value is a
+	// list), accepting any scalar-castable type.
+	{
+		v := arena.MakeVar(0)
+		out[names.Intern("urlEncode")] = []QuoteSig{
+			{Inputs: []TypeId{TidStr}, Outputs: []TypeId{TidStr}},
+			{
+				Inputs:   []TypeId{arena.MakeDict(TidStr, v)},
+				Outputs:  []TypeId{TidStr},
+				Generics: []TypeVarId{0},
+			},
+		}
+	}
 	// zipPack validates entry dictionaries at runtime. The checker
 	// keeps the stack effect broad until dictionary shape tracking is
 	// precise enough to express the required keys.

--- a/mshell/TypeBuiltins.go
+++ b/mshell/TypeBuiltins.go
@@ -1428,9 +1428,7 @@ func builtinSigsByName(arena *TypeArena, names *NameTable) map[NameId][]QuoteSig
 		Inputs:  []TypeId{TidStr},
 		Outputs: []TypeId{TidBytes},
 	}}
-	// urlEncode :
-	//   (str -- str)
-	//   ({str: str|int|path|[str]|[int]|[path]} -- str)
+	// urlEncode : (str | {str: str|int|path|[str]|[int]|[path]} -- str)
 	//
 	// Dict values must be a scalar the runtime can CastString, or a
 	// list of such scalars (lists become repeated `k=v` pairs). The
@@ -1444,13 +1442,14 @@ func builtinSigsByName(arena *TypeArena, names *NameTable) map[NameId][]QuoteSig
 			arena.MakeList(TidInt),
 			arena.MakeList(TidPath),
 		}, 0)
-		out[names.Intern("urlEncode")] = []QuoteSig{
-			{Inputs: []TypeId{TidStr}, Outputs: []TypeId{TidStr}},
-			{
-				Inputs:  []TypeId{arena.MakeDict(TidStr, valueU)},
-				Outputs: []TypeId{TidStr},
-			},
-		}
+		inputU := arena.MakeUnion([]TypeId{
+			TidStr,
+			arena.MakeDict(TidStr, valueU),
+		}, 0)
+		out[names.Intern("urlEncode")] = []QuoteSig{{
+			Inputs:  []TypeId{inputU},
+			Outputs: []TypeId{TidStr},
+		}}
 	}
 	// zipPack validates entry dictionaries at runtime. The checker
 	// keeps the stack effect broad until dictionary shape tracking is

--- a/mshell/TypeBuiltins.go
+++ b/mshell/TypeBuiltins.go
@@ -1428,19 +1428,27 @@ func builtinSigsByName(arena *TypeArena, names *NameTable) map[NameId][]QuoteSig
 		Inputs:  []TypeId{TidStr},
 		Outputs: []TypeId{TidBytes},
 	}}
-	// urlEncode : (str -- str) | ({str: T} -- str)
+	// urlEncode :
+	//   (str -- str)
+	//   ({str: str|int|path|[str]|[int]|[path]} -- str)
 	//
-	// Dict input stays loose ({str: T}) because the runtime calls
-	// CastString on each value (and on each item if the value is a
-	// list), accepting any scalar-castable type.
+	// Dict values must be a scalar the runtime can CastString, or a
+	// list of such scalars (lists become repeated `k=v` pairs). The
+	// runtime's CastString succeeds only on str/int/path/literal, so
+	// float, bool, bytes, datetime, maybe, nested list, and nested
+	// dict all crash — exclude them from the signature.
 	{
-		v := arena.MakeVar(0)
+		valueU := arena.MakeUnion([]TypeId{
+			TidStr, TidInt, TidPath,
+			arena.MakeList(TidStr),
+			arena.MakeList(TidInt),
+			arena.MakeList(TidPath),
+		}, 0)
 		out[names.Intern("urlEncode")] = []QuoteSig{
 			{Inputs: []TypeId{TidStr}, Outputs: []TypeId{TidStr}},
 			{
-				Inputs:   []TypeId{arena.MakeDict(TidStr, v)},
-				Outputs:  []TypeId{TidStr},
-				Generics: []TypeVarId{0},
+				Inputs:  []TypeId{arena.MakeDict(TidStr, valueU)},
+				Outputs: []TypeId{TidStr},
 			},
 		}
 	}

--- a/tests/success/urlencode.msh
+++ b/tests/success/urlencode.msh
@@ -1,0 +1,2 @@
+"hello world" urlEncode wl
+{"q": "go lang", "n": 2} urlEncode wl

--- a/tests/success/urlencode.msh
+++ b/tests/success/urlencode.msh
@@ -1,2 +1,4 @@
 "hello world" urlEncode wl
 {"q": "go lang", "n": 2} urlEncode wl
+{"tag": ["a" "b" "c"]} urlEncode wl
+{"n": [1 2 3]} urlEncode wl

--- a/tests/success/urlencode.msh
+++ b/tests/success/urlencode.msh
@@ -1,4 +1,9 @@
 "hello world" urlEncode wl
+"a&b=c?d e" urlEncode wl
+"100% off" urlEncode wl
+"slash/and+plus" urlEncode wl
+"unicode: café" urlEncode wl
 {"q": "go lang", "n": 2} urlEncode wl
 {"tag": ["a" "b" "c"]} urlEncode wl
 {"n": [1 2 3]} urlEncode wl
+{"q": "a&b=c"} urlEncode wl

--- a/tests/success/urlencode.msh.stdout
+++ b/tests/success/urlencode.msh.stdout
@@ -1,2 +1,4 @@
 hello+world
 n=2&q=go+lang
+tag=a&tag=b&tag=c
+n=1&n=2&n=3

--- a/tests/success/urlencode.msh.stdout
+++ b/tests/success/urlencode.msh.stdout
@@ -1,0 +1,2 @@
+hello+world
+n=2&q=go+lang

--- a/tests/success/urlencode.msh.stdout
+++ b/tests/success/urlencode.msh.stdout
@@ -1,4 +1,9 @@
 hello+world
+a%26b%3Dc%3Fd+e
+100%25+off
+slash%2Fand%2Bplus
+unicode%3A+caf%C3%A9
 n=2&q=go+lang
 tag=a&tag=b&tag=c
 n=1&n=2&n=3
+q=a%26b%3Dc


### PR DESCRIPTION
Why: urlEncode was registered in BuiltInList.go and handled in Evaluator.go but missing from TypeBuiltins.go, so the type checker rejected any program using it.

Signature mirrors the runtime: (str -- str) and ({str: T} -- str), loose on dict values because the runtime calls CastString on them.