### PR TITLE
Preserve argument-position literals in :: CLI shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the actual process environment as well as any environment variables already
   referenced in the current file.
 
+### Fixed
+
+- In the interactive `::` CLI shorthand, bare literals in argument position are no
+  longer turned into strings, so operators work again (e.g. `:: numargs '*' glob`
+  now runs `glob` as the wildcard operator instead of passing the word `glob`).
+  The leading command name is still treated as a command, so an executable continues
+  to win over a builtin of the same name (e.g. `date`, `sort`).
+
 ### Changed
 
 - A command that cannot start (not found, permission denied, bad format, ...) run

--- a/mshell/SimpleCliParser.go
+++ b/mshell/SimpleCliParser.go
@@ -284,22 +284,35 @@ func (pipeline *SimpleCliPipeline) ToMShellFile() (*MShellFile, error) {
 	}, nil
 }
 
-// convertItemsForExecution converts parsed items for use in a command list.
-// Literals are converted to single-quoted strings for execution.
+// convertItemsForExecution converts the parsed items of a single command for execution.
+//
+// The first item is the command name: a bare literal is converted to a single-quoted
+// string so that an executable always wins over a builtin/operator of the same name
+// (e.g. `date`, `sort`, `cp`). This matches the long-standing CLI behavior.
+//
+// Every remaining item is preserved as-is. At runtime, a literal in argument position
+// that names a builtin or definition acts as that operator (e.g. `'*' glob` expands the
+// wildcard), and any other literal is treated as a string. We deliberately do NOT quote
+// these, so operators keep working as a direct AST transformation rather than relying on
+// string manipulation.
 func convertItemsForExecution(items []MShellParseItem) []MShellParseItem {
 	result := make([]MShellParseItem, len(items))
 	for i, item := range items {
-		result[i] = convertItemForExecution(item)
+		if i == 0 {
+			result[i] = convertCommandNameForExecution(item)
+		} else {
+			result[i] = item
+		}
 	}
 	return result
 }
 
-// convertItemForExecution converts a single parsed item for execution.
-// Literals become single-quoted strings, other types are preserved.
-func convertItemForExecution(item MShellParseItem) MShellParseItem {
+// convertCommandNameForExecution converts a command-name item for execution.
+// A bare LITERAL becomes a single-quoted string so the command wins over any
+// builtin/operator of the same name; other types are preserved as-is.
+func convertCommandNameForExecution(item MShellParseItem) MShellParseItem {
 	switch v := item.(type) {
 	case Token:
-		// Convert LITERAL tokens to SINGLEQUOTESTRING for execution
 		if v.Type == LITERAL {
 			return Token{
 				Type:   SINGLEQUOTESTRING,

--- a/mshell/SimpleCliParser_test.go
+++ b/mshell/SimpleCliParser_test.go
@@ -375,3 +375,49 @@ func TestSimpleCliParser_ToMShellFile_ListArgument(t *testing.T) {
 		t.Errorf("Expected fourth item to be MShellParseList, got %T", cmdList.Items[3])
 	}
 }
+
+// The command name (first item) is force-quoted so an executable wins over a
+// builtin of the same name, but argument-position literals are preserved as
+// LITERAL tokens so operators like `glob` still act as operators at runtime.
+func TestSimpleCliParser_ToMShellFile_ArgLiteralsPreserved(t *testing.T) {
+	input := "numargs '*' glob"
+	l := NewLexer(input, nil)
+	p := NewMShellSimpleCliParser(l)
+
+	pipeline, err := p.Parse()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	file, fileErr := pipeline.ToMShellFile()
+	if fileErr != nil {
+		t.Fatalf("Unexpected error: %v", fileErr)
+	}
+
+	cmdList, ok := file.Items[0].(*MShellParseList)
+	if !ok {
+		t.Fatalf("Expected first item to be MShellParseList, got %T", file.Items[0])
+	}
+
+	if len(cmdList.Items) != 3 {
+		t.Fatalf("Expected 3 items in command list, got %d", len(cmdList.Items))
+	}
+
+	// Command name: bare literal becomes a single-quoted string.
+	cmdName, ok := cmdList.Items[0].(Token)
+	if !ok || cmdName.Type != SINGLEQUOTESTRING {
+		t.Errorf("Expected command name to be SINGLEQUOTESTRING, got %T %v", cmdList.Items[0], cmdList.Items[0])
+	}
+
+	// Already-quoted argument is preserved as-is.
+	starArg, ok := cmdList.Items[1].(Token)
+	if !ok || starArg.Type != SINGLEQUOTESTRING {
+		t.Errorf("Expected '*' arg to be SINGLEQUOTESTRING, got %T %v", cmdList.Items[1], cmdList.Items[1])
+	}
+
+	// Bare literal argument (an operator) is preserved as a LITERAL, NOT quoted.
+	globArg, ok := cmdList.Items[2].(Token)
+	if !ok || globArg.Type != LITERAL {
+		t.Errorf("Expected 'glob' arg to remain LITERAL, got %T %v", cmdList.Items[2], cmdList.Items[2])
+	}
+}


### PR DESCRIPTION
The interactive :: CLI shorthand wrapped each command in a list and converted every bare literal to a single-quoted string. That turned operators in argument position into plain strings, e.g. `:: numargs '*' glob` passed the word "glob" instead of running the glob wildcard operator. This regressed in the #110 CLI Pipeline rewrite, which replaced raw-lexeme string building (args left untouched) with a blanket literal-to-string AST conversion.

Only force-quote the leading command name now, so an executable still wins over a builtin of the same name (date, sort, cp, ...). Argument-position literals are preserved as LITERAL tokens; at runtime a literal naming a builtin/definition acts as that operator and any other literal becomes a string.