### PR TITLE
Bind names in type-keyword match arms; fix interpolation diagnostic p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The language server now offers completion on `$` environment variables, drawing
   from the actual process environment as well as any environment variables already
   referenced in the current file.
+- `match` arms can now bind the matched value when matching on a type keyword by
+  following it with a name, e.g. `str s : @s len` (mirroring `just v`). Works for
+  every type keyword (`int`, `float`, `str`, `bool`, `list`, `dict`, `path`,
+  `date`, `quotation`, `maybe`, `binary`).
 
 ### Fixed
+
+- Match arms that are not a recognized pattern form now produce a clear error
+  listing the legal forms, instead of silently failing to bind (and later
+  reporting a confusing "unknown identifier" in the arm body).
+- Type-checker diagnostics for unknown identifiers inside a `$"...{ }"` format
+  string interpolation now point at the interpolation's actual source location
+  rather than line 1, column 1.
 
 - The type checker now joins the arms of a `match` or `if`/`else` block into a
   single union post-state instead of treating each arm as an independent

--- a/doc/control-flow.inc.html
+++ b/doc/control-flow.inc.html
@@ -208,6 +208,18 @@ Supported type patterns: <code>int</code>, <code>float</code>, <code>str</code>,
 <span class="mshellEND">end</span> <span class="mshellLITERAL">wl</span> <span class="mshellLINECOMMENT"># Output: integer</span></code>
 </pre>
 
+<p>
+Follow a type pattern with a name to bind the matched value, just like <code>just v</code>:
+</p>
+
+<pre>
+<code><span class="mshellSTRING">"hello"</span> <span class="mshellMATCH">match</span>
+    <span class="mshellLITERAL">int</span> <span class="mshellLITERAL">n</span> : <span class="mshellVARRETRIEVE">@n</span> <span class="mshellLITERAL">str</span>,
+    <span class="mshellLITERAL">str</span> <span class="mshellLITERAL">s</span> : <span class="mshellVARRETRIEVE">@s</span> <span class="mshellLITERAL">len</span> <span class="mshellLITERAL">str</span>,
+    <span class="mshellLITERAL">_</span>     : <span class="mshellSTRING">"other"</span>,
+<span class="mshellEND">end</span> <span class="mshellLITERAL">wl</span> <span class="mshellLINECOMMENT"># Output: 5</span></code>
+</pre>
+
 <h2>Wildcard</h2>
 
 <p>The <code>_</code> pattern matches any value and acts as a catch-all:</p>

--- a/doc/mshell.md
+++ b/doc/mshell.md
@@ -853,6 +853,16 @@ Type keywords match based on the subject's type:
 end wl # Output: integer
 ```
 
+Follow a type keyword with a name to bind the matched value (like `just v`):
+
+```mshell
+"hello" match
+    int n : @n str,
+    str s : @s len str,
+    _     : "other",
+end wl # Output: 5
+```
+
 ### Maybe Destructuring
 
 `just v` matches a Maybe that is Just, binding the inner value to `v`.

--- a/mshell/Evaluator.go
+++ b/mshell/Evaluator.go
@@ -1043,35 +1043,54 @@ func (state *EvalState) processMatchBlock(matchBlock *MShellParseMatchBlock, fra
 // matchPattern checks if a subject matches a pattern (list of parse items).
 // Returns (matched bool, bindings map, result EvalResult).
 func (state *EvalState) matchPattern(pattern []MShellParseItem, subject MShellObject, startToken Token) (bool, map[string]MShellObject, EvalResult) {
-	// Handle multi-token patterns (e.g., "just v" for maybe destructuring)
+	// Handle multi-token patterns (e.g., "just v" for maybe destructuring,
+	// or "<typekeyword> name" for type-test binding).
 	if len(pattern) == 2 {
 		first, firstOk := pattern[0].(Token)
 		second, secondOk := pattern[1].(Token)
-		if firstOk && secondOk && first.Type == LITERAL && first.Lexeme == "just" {
-			// Maybe Just destructuring
-			var maybeVal Maybe
-			var ok bool
-			switch m := subject.(type) {
-			case Maybe:
-				maybeVal = m
-				ok = true
-			case *Maybe:
-				maybeVal = *m
-				ok = true
+		if firstOk && secondOk && second.Type == LITERAL {
+			if first.Type == LITERAL && first.Lexeme == "just" {
+				// Maybe Just destructuring
+				var maybeVal Maybe
+				var ok bool
+				switch m := subject.(type) {
+				case Maybe:
+					maybeVal = m
+					ok = true
+				case *Maybe:
+					maybeVal = *m
+					ok = true
+				}
+				if !ok || maybeVal.IsNone() {
+					return false, nil, SimpleSuccess()
+				}
+				bindings := make(map[string]MShellObject)
+				if second.Lexeme != "_" {
+					bindings[second.Lexeme] = maybeVal.obj
+				}
+				return true, bindings, SimpleSuccess()
 			}
-			if !ok || maybeVal.IsNone() {
-				return false, nil, SimpleSuccess()
+			// `<typekeyword> name`: match on the type, then bind the
+			// matched value to name.
+			if isTypeKeywordToken(first) {
+				matched, result := state.matchTokenPattern(first, subject)
+				if !result.Success {
+					return false, nil, result
+				}
+				if !matched {
+					return false, nil, SimpleSuccess()
+				}
+				bindings := make(map[string]MShellObject)
+				if second.Lexeme != "_" {
+					bindings[second.Lexeme] = subject
+				}
+				return true, bindings, SimpleSuccess()
 			}
-			bindings := make(map[string]MShellObject)
-			if second.Type == LITERAL && second.Lexeme != "_" {
-				bindings[second.Lexeme] = maybeVal.obj
-			}
-			return true, bindings, SimpleSuccess()
 		}
 	}
 
 	if len(pattern) != 1 {
-		return false, nil, state.FailWithMessage(fmt.Sprintf("%d:%d: Match arm pattern must be a single item (or 'just <binding>').\n", startToken.Line, startToken.Column))
+		return false, nil, state.FailWithMessage(fmt.Sprintf("%d:%d: Match arm pattern must be a single item, 'just <name>', or '<type> <name>'. %s\n", startToken.Line, startToken.Column, matchPatternFormsHint))
 	}
 
 	patternItem := pattern[0]
@@ -1136,7 +1155,7 @@ func (state *EvalState) matchTokenPattern(p Token, subject MShellObject) (bool, 
 			_, ok := subject.(MShellBinary)
 			return ok, SimpleSuccess()
 		}
-		return false, state.FailWithMessage(fmt.Sprintf("%d:%d: Unknown match pattern literal '%s'.\n", p.Line, p.Column, p.Lexeme))
+		return false, state.FailWithMessage(fmt.Sprintf("%d:%d: Unknown match pattern literal '%s'. %s\n", p.Line, p.Column, p.Lexeme, matchPatternFormsHint))
 
 	case TYPEINT:
 		_, ok := subject.(MShellInt)

--- a/mshell/TypeCheckProgram.go
+++ b/mshell/TypeCheckProgram.go
@@ -1131,6 +1131,13 @@ func (c *Checker) checkMatchBlock(matchBlock *MShellParseMatchBlock) {
 	var armLabels []string
 	tags := make([]MatchArmTag, 0, len(matchBlock.Arms))
 	for _, arm := range matchBlock.Arms {
+		if len(arm.Pattern) > 0 && !c.armPatternRecognized(arm.Pattern) {
+			c.errors = append(c.errors, TypeError{
+				Kind: TErrInvalidMatchPattern,
+				Pos:  arm.Pattern[0].GetStartToken(),
+				Hint: matchPatternFormsHint,
+			})
+		}
 		c.loadBranch(entry)
 		c.diverged = false
 		// Apply per-arm subject handling.
@@ -1220,13 +1227,127 @@ func (c *Checker) classifyArmPattern(pattern []MShellParseItem) MatchArmTag {
 		}
 	}
 	if len(pattern) == 2 {
-		if t0, ok := pattern[0].(Token); ok && t0.Type == LITERAL && t0.Lexeme == "just" {
-			if _, ok := pattern[1].(Token); ok {
+		t0, ok0 := pattern[0].(Token)
+		t1, ok1 := pattern[1].(Token)
+		if ok0 && ok1 && t1.Type == LITERAL {
+			if t0.Type == LITERAL && t0.Lexeme == "just" {
 				return MatchArmTag{Kind: MatchArmJust}
+			}
+			// `<typekeyword> name` binds the matched value; for
+			// exhaustiveness it covers the same type as the bare keyword.
+			if tid, ok := c.typeKeywordTokenType(t0); ok {
+				return MatchArmTag{Kind: MatchArmType, TypeArm: tid}
+			}
+			if tid := c.LookupType(t0.Lexeme); t0.Type == LITERAL && tid != TidNothing {
+				return MatchArmTag{Kind: MatchArmType, TypeArm: tid}
 			}
 		}
 	}
 	return MatchArmTag{Kind: MatchArmType, TypeArm: TidNothing}
+}
+
+// typeKeywordTokenType maps a match type-keyword token to the concrete
+// TypeId it tests for. Container/other keywords (list, dict, quotation,
+// maybe) have no single primitive id and return ok=false; callers that
+// need a binding type fall back to a fresh var or the subject.
+func (c *Checker) typeKeywordTokenType(tok Token) (TypeId, bool) {
+	switch tok.Type {
+	case TYPEINT:
+		return TidInt, true
+	case TYPEFLOAT:
+		return TidFloat, true
+	case TYPEBOOL:
+		return TidBool, true
+	case STR:
+		return TidStr, true
+	case LITERAL:
+		switch tok.Lexeme {
+		case "path":
+			return TidPath, true
+		case "date":
+			return TidDateTime, true
+		case "binary":
+			return TidBytes, true
+		}
+	}
+	return TidNothing, false
+}
+
+// isTypeKeywordToken reports whether tok is one of the match type-keyword
+// patterns: int, float, str, bool, list, dict, path, date, quotation,
+// maybe, binary.
+func isTypeKeywordToken(tok Token) bool {
+	switch tok.Type {
+	case TYPEINT, TYPEFLOAT, STR, TYPEBOOL:
+		return true
+	case LITERAL:
+		switch tok.Lexeme {
+		case "list", "dict", "path", "date", "quotation", "maybe", "binary":
+			return true
+		}
+	}
+	return false
+}
+
+// matchPatternFormsHint lists the legal match-arm pattern forms, used in
+// the diagnostic raised when an arm pattern is not recognized.
+const matchPatternFormsHint = "expected one of: `_`; a type keyword " +
+	"(int, float, str, bool, list, dict, path, date, quotation, maybe, binary), " +
+	"optionally followed by a binding name; a value literal (42, 1.5, \"text\", true, false, PATH); " +
+	"`none`; `just <name>`; a list pattern `[ ... ]`; or a dict pattern `{ ... }`"
+
+// armPatternRecognized reports whether pattern is one of the legal
+// match-arm forms. Unrecognized patterns get a TErrInvalidMatchPattern
+// diagnostic rather than silently binding nothing.
+func (c *Checker) armPatternRecognized(pattern []MShellParseItem) bool {
+	switch len(pattern) {
+	case 1:
+		switch p := pattern[0].(type) {
+		case *MShellParseList, *MShellParseDict:
+			return true
+		case Token:
+			return c.tokenPatternRecognized(p)
+		}
+		return false
+	case 2:
+		t0, ok0 := pattern[0].(Token)
+		t1, ok1 := pattern[1].(Token)
+		if !ok0 || !ok1 || t1.Type != LITERAL {
+			return false
+		}
+		if t0.Type == LITERAL && t0.Lexeme == "just" {
+			return true
+		}
+		if isTypeKeywordToken(t0) {
+			return true
+		}
+		if t0.Type == LITERAL && c.LookupType(t0.Lexeme) != TidNothing {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+// tokenPatternRecognized reports whether a single-token pattern is legal:
+// a type keyword, value literal, `_`, `none`, or a user-declared type name.
+func (c *Checker) tokenPatternRecognized(tok Token) bool {
+	switch tok.Type {
+	case TYPEINT, TYPEFLOAT, STR, TYPEBOOL,
+		INTEGER, FLOAT, STRING, SINGLEQUOTESTRING, PATH, TRUE, FALSE:
+		return true
+	case LITERAL:
+		if tok.Lexeme == "_" || tok.Lexeme == "none" {
+			return true
+		}
+		if isTypeKeywordToken(tok) {
+			return true
+		}
+		if c.LookupType(tok.Lexeme) != TidNothing {
+			return true
+		}
+	}
+	return false
 }
 
 // narrowMatchSubject returns the concrete primitive type that a
@@ -1276,20 +1397,34 @@ func (c *Checker) bindPatternName(name string, typ TypeId, bindings *[]patternBi
 func (c *Checker) bindMatchPattern(subject TypeId, pattern []MShellParseItem) []patternBinding {
 	var bindings []patternBinding
 
-	// `just v`
+	// `just v` and `<typekeyword> name`
 	if len(pattern) != 2 {
 		goto single
 	}
 	if first, ok1 := pattern[0].(Token); ok1 {
-		if second, ok2 := pattern[1].(Token); ok2 &&
-			first.Type == LITERAL && first.Lexeme == "just" &&
-			second.Type == LITERAL && second.Lexeme != "_" {
-			resolved := c.subst.Apply(c.arena, subject)
-			n := c.arena.Node(resolved)
-			if n.Kind == TKMaybe {
-				c.bindPatternName(second.Lexeme, TypeId(n.A), &bindings)
+		if second, ok2 := pattern[1].(Token); ok2 && second.Type == LITERAL {
+			if first.Type == LITERAL && first.Lexeme == "just" {
+				if second.Lexeme != "_" {
+					resolved := c.subst.Apply(c.arena, subject)
+					n := c.arena.Node(resolved)
+					if n.Kind == TKMaybe {
+						c.bindPatternName(second.Lexeme, TypeId(n.A), &bindings)
+					}
+				}
+				return bindings
 			}
-			return bindings
+			// `<typekeyword> name` binds the matched value to the type
+			// the keyword tests for. Container/other keywords have no
+			// single primitive id; bind to the subject (the runtime
+			// binds the value as-is) which is sound if wider.
+			if isTypeKeywordToken(first) {
+				bindType, ok := c.typeKeywordTokenType(first)
+				if !ok {
+					bindType = c.subst.Apply(c.arena, subject)
+				}
+				c.bindPatternName(second.Lexeme, bindType, &bindings)
+				return bindings
+			}
 		}
 	}
 
@@ -1371,12 +1506,47 @@ func (c *Checker) checkFormatStringInterpolations(tok Token) {
 		case modeFormat:
 			if ch == '}' {
 				inner := string(runes[startIdx:i])
-				c.checkFormatBlock(inner, tok)
+				// Map the block's first content rune back to its
+				// position in the original source so inner diagnostics
+				// point at the interpolation, not 1:1.
+				baseLine, baseCol := runePosition(runes, startIdx, tok.Line, tok.Column)
+				c.checkFormatBlock(inner, tok, baseLine, baseCol)
 				mode = modeNormal
 				startIdx = -1
 			}
 		}
 	}
+}
+
+// runePosition returns the one-based (line, column) of runes[idx] given
+// that runes[0] sits at (baseLine, baseCol). Newlines reset the column to
+// 1; every other rune advances the column by one.
+func runePosition(runes []rune, idx, baseLine, baseCol int) (int, int) {
+	line, col := baseLine, baseCol
+	for i := 0; i < idx && i < len(runes); i++ {
+		if runes[i] == '\n' {
+			line++
+			col = 1
+		} else {
+			col++
+		}
+	}
+	return line, col
+}
+
+// remapBlockToken rewrites a token's position from format-block-local
+// coordinates (where the block source starts at line 1, column 1) to the
+// surrounding source, given that the block content begins at
+// (baseLine, baseCol). Lines past the first already start at column 1 in
+// both coordinate systems, so only their line number shifts.
+func remapBlockToken(t Token, baseLine, baseCol int) Token {
+	if t.Line == 1 {
+		t.Column = baseCol + (t.Column - 1)
+		t.Line = baseLine
+	} else {
+		t.Line = baseLine + (t.Line - 1)
+	}
+	return t
 }
 
 // checkFormatBlock lexes/parses one interpolation block and walks its
@@ -1385,7 +1555,7 @@ func (c *Checker) checkFormatStringInterpolations(tok Token) {
 // reported against the format-string token's position — finer source
 // mapping inside the block is left for a follow-up. The outer stack
 // and substitution are restored before returning.
-func (c *Checker) checkFormatBlock(src string, callSite Token) {
+func (c *Checker) checkFormatBlock(src string, callSite Token, baseLine, baseCol int) {
 	lex := NewLexer(src, nil)
 	parser := NewMShellParser(lex)
 	file, err := parser.ParseFile()
@@ -1402,8 +1572,14 @@ func (c *Checker) checkFormatBlock(src string, callSite Token) {
 	cp := c.subst.Checkpoint()
 	c.stack.items = nil
 
+	errStart := len(c.errors)
 	for _, item := range file.Items {
 		c.checkParseItem(item)
+	}
+	// Diagnostics raised while walking the block carry block-local
+	// positions; shift them back onto the original source.
+	for i := errStart; i < len(c.errors); i++ {
+		c.errors[i].Pos = remapBlockToken(c.errors[i].Pos, baseLine, baseCol)
 	}
 
 	if c.stack.Len() != 1 {

--- a/mshell/TypeCheckProgram_test.go
+++ b/mshell/TypeCheckProgram_test.go
@@ -1022,3 +1022,39 @@ func TestTypeCheckProgramDbgInValidProgramPasses(t *testing.T) {
 		t.Fatalf("expected valid program with dbg to pass; errs=%v", errs)
 	}
 }
+
+func TestTypeCheckMatchTypeKeywordBinding(t *testing.T) {
+	// `str s` matches a string subject and binds `s` to it for the body.
+	errs, ok := parseAndCheck(t, `"hi" match str s : @s wl, _ : "x" wl end`)
+	if !ok || len(errs) != 0 {
+		t.Fatalf("expected `str s` binding to type-check; errs=%v ok=%v", errs, ok)
+	}
+}
+
+func TestTypeCheckMatchInvalidPatternDiagnostic(t *testing.T) {
+	// `string` is not a recognized type keyword (the keyword is `str`),
+	// so the arm pattern is rejected with the forms diagnostic.
+	errs, ok := parseAndCheck(t, `"hi" match string s : @s wl, _ : "x" wl end`)
+	if ok {
+		t.Fatalf("expected `string s` to be rejected; errs=%v", errs)
+	}
+	if len(errs) == 0 || !strings.Contains(errs[0], "unrecognized match arm pattern 'string'") {
+		t.Fatalf("expected unrecognized-pattern diagnostic; errs=%v", errs)
+	}
+}
+
+func TestTypeCheckInterpolationUnknownIdentPosition(t *testing.T) {
+	// The diagnostic for an unbound var inside a `${...}` interpolation
+	// must point at the interpolation, not the format-string's 1:1.
+	errs, ok := parseAndCheck(t, "$\"value {@missing}\"")
+	if ok {
+		t.Fatalf("expected unknown-identifier error; errs=%v", errs)
+	}
+	if len(errs) == 0 || !strings.Contains(errs[0], "@missing") {
+		t.Fatalf("expected @missing diagnostic; errs=%v", errs)
+	}
+	// `@` sits at column 10 of the single source line.
+	if !strings.Contains(errs[0], "line 1, column 10") {
+		t.Fatalf("expected diagnostic at line 1, column 10; got %v", errs)
+	}
+}

--- a/mshell/TypeError.go
+++ b/mshell/TypeError.go
@@ -40,6 +40,9 @@ const (
 	TErrInvalidCast
 	TErrTypeParse
 	TErrInterpolationArity
+	// TErrInvalidMatchPattern is emitted when a match arm pattern is not
+	// one of the recognized forms. Hint lists the legal forms.
+	TErrInvalidMatchPattern
 	// TErrDebugDump is emitted by the `dbg` builtin at each branch
 	// that walks past it. Informational severity — does not fail the
 	// type check. Hint holds the formatted snapshot of stack + vars.
@@ -134,6 +137,11 @@ func (e TypeError) Format(arena *TypeArena, names *NameTable) string {
 		fmt.Fprintf(&sb, "type parse error: %s", e.Hint)
 	case TErrInterpolationArity:
 		fmt.Fprintf(&sb, "%s", e.Hint)
+	case TErrInvalidMatchPattern:
+		fmt.Fprintf(&sb, "unrecognized match arm pattern '%s'", e.Pos.Lexeme)
+		if e.Hint != "" {
+			fmt.Fprintf(&sb, " (%s)", e.Hint)
+		}
 	case TErrDefBodyMismatch:
 		// Hint carries the human-readable "declared vs body"
 		// description. Pos is the def's name token (the body could


### PR DESCRIPTION
…osition

Match arms can now bind the matched value when matching on a type keyword by following it with a name (e.g. `str s : @s len`), mirroring `just v`, for every type keyword. Unrecognized arm patterns now report a clear error listing the legal forms instead of silently failing to bind.

Type-checker diagnostics for unknown identifiers inside a `$"...{ }"` format-string interpolation now point at the interpolation's actual source location rather than line 1, column 1.