### PR TITLE
Fix command path separator for windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- On Windows, a command name containing a forward slash (e.g. `./script.msh`)
+  is now treated as a file reference instead of being searched for on `PATH`,
+  matching the behavior on Linux/macOS. Previously only backslashes were
+  recognized as path separators in command position on Windows, so
+  cross-platform scripts invoking local scripts with `./` failed.
 - Interactive programs now work as a stage of a pipeline. A command that drives
   the terminal (e.g. `... | nvim -`, `... | less`, `... | fzf`) is no longer
   stopped on startup: every external stage of a pipeline is now placed in one

--- a/mshell/Evaluator.go
+++ b/mshell/Evaluator.go
@@ -3870,8 +3870,10 @@ func RunProcess(list MShellList, context ExecuteContext, state *EvalState) (Eval
 	var allArgs []string
 	var cmdPath string
 
-	// Check if there is a directory separator in the name of the command trying to execute
-	if strings.Contains(commandLineArgs[0], string(os.PathSeparator)) {
+	// Check if there is a directory separator in the name of the command trying to execute.
+	// Use the platform IsPathSeparator so that './script' is a file reference on Windows too,
+	// where os.PathSeparator alone would miss the forward slash.
+	if strings.ContainsFunc(commandLineArgs[0], func(r rune) bool { return r < 256 && IsPathSeparator(uint8(r)) }) {
 		cmdPath = commandLineArgs[0]
 	} else {
 		var found bool


### PR DESCRIPTION
Basically want

[./my_script.msh ];

to work on both Unix and Windows.